### PR TITLE
Initialize Next.js frontend and Express backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+frontend/node_modules
+backend/node_modules
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# AI-Customer-Support-Agent
+# AI Customer Support Agent
+
+This repository contains a prototype for an AI-powered customer support agent. It includes a Next.js 14 frontend using Tailwind CSS and Framer Motion and an Express backend with Sequelize and PostgreSQL.
+
+## Structure
+
+- `frontend/` – Next.js application with chat interface and a dummy analytics dashboard.
+- `backend/` – Express server with placeholder routes for chat and analytics.
+
+## Development
+
+Install dependencies for each package and run their respective development servers.
+
+```
+cd frontend && npm install && npm run dev
+```
+```
+cd backend && npm install && npm start
+```
+
+### Environment
+
+The backend integrates with the OpenAI API for generating answers, sentiment, and voice output. Provide an API key before starting the server:
+
+```
+export OPENAI_API_KEY=your_key_here
+```
+
+The project currently provides only a minimal skeleton and does not implement full AI functionality. The frontend ships with dummy chat history and analytics so the UI can be previewed without the backend.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const fileUpload = require('express-fileupload');
+const { sequelize } = require('./models');
+const chatRoutes = require('./routes/chat');
+const analyticsRoutes = require('./routes/analytics');
+
+const app = express();
+app.use(bodyParser.json());
+app.use(fileUpload());
+
+app.post('/api/upload', (req, res) => {
+  res.json({ status: 'uploaded' });
+});
+
+app.use('/api/chat', chatRoutes);
+app.use('/api/analytics', analyticsRoutes);
+
+const PORT = process.env.PORT || 3001;
+sequelize.sync().then(() => {
+  app.listen(PORT, () => console.log(`Server running on ${PORT}`));
+});

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,0 +1,8 @@
+const { Sequelize } = require('sequelize');
+
+const sequelize = new Sequelize(process.env.DATABASE_URL || 'postgres://user:pass@localhost:5432/aicsa', {
+  dialect: 'postgres',
+  logging: false,
+});
+
+module.exports = { sequelize, Sequelize };

--- a/backend/models/query.js
+++ b/backend/models/query.js
@@ -1,0 +1,9 @@
+const { DataTypes } = require('sequelize');
+const { sequelize } = require('./index');
+
+const Query = sequelize.define('Query', {
+  question: DataTypes.TEXT,
+  sentiment: DataTypes.STRING,
+});
+
+module.exports = Query;

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "express": "4.18.2",
+    "body-parser": "1.20.2",
+    "sequelize": "6.35.1",
+    "pg": "8.10.0",
+    "express-fileupload": "1.4.0",
+    "openai": "^4.24.1"
+  }
+}

--- a/backend/routes/analytics.js
+++ b/backend/routes/analytics.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const router = express.Router();
+const Query = require('../models/query');
+const { sequelize } = require('../models');
+
+router.get('/', async (req, res) => {
+  const total = await Query.count();
+  const angry = await Query.count({ where: { sentiment: 'angry' } });
+  const happy = await Query.count({ where: { sentiment: 'happy' } });
+  const top = await Query.findAll({
+    attributes: ['question', [sequelize.fn('COUNT', sequelize.col('question')), 'count']],
+    group: ['question'],
+    order: [[sequelize.literal('count'), 'DESC']],
+    limit: 3,
+  });
+  res.json({ total, angry, happy, top });
+});
+
+module.exports = router;

--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const router = express.Router();
+const Query = require('../models/query');
+const openai = require('../services/openai');
+
+router.post('/', async (req, res) => {
+  const { question } = req.body;
+  let answer = 'Placeholder answer';
+  let sentiment = 'neutral';
+  let audio = null;
+
+  try {
+    if (openai) {
+      const completion = await openai.chat.completions.create({
+        model: 'gpt-4o-mini',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are a helpful support agent. Reply in JSON with keys answer and sentiment (angry, neutral, happy).',
+          },
+          { role: 'user', content: question },
+        ],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'response',
+            schema: {
+              type: 'object',
+              properties: {
+                answer: { type: 'string' },
+                sentiment: { type: 'string' },
+              },
+              required: ['answer', 'sentiment'],
+              additionalProperties: false,
+            },
+          },
+        },
+      });
+
+      const parsed = JSON.parse(completion.choices[0].message.content);
+      answer = parsed.answer;
+      sentiment = parsed.sentiment;
+
+      const speech = await openai.audio.speech.create({
+        model: 'gpt-4o-mini-tts',
+        voice: 'alloy',
+        input: answer,
+      });
+      audio = Buffer.from(await speech.arrayBuffer()).toString('base64');
+    }
+  } catch (err) {
+    console.error(err);
+  }
+
+  await Query.create({ question, sentiment });
+  res.json({ answer, sentiment, audio, sources: [] });
+});
+
+module.exports = router;

--- a/backend/services/openai.js
+++ b/backend/services/openai.js
@@ -1,0 +1,8 @@
+const OpenAI = require('openai');
+
+let client = null;
+if (process.env.OPENAI_API_KEY) {
+  client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+}
+
+module.exports = client;

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/app/layout.jsx
+++ b/frontend/app/layout.jsx
@@ -1,0 +1,13 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'AI Customer Support',
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body className="bg-gray-50">{children}</body>
+    </html>
+  );
+}

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -1,0 +1,14 @@
+import Chat from '../components/Chat';
+import Dashboard from '../components/Dashboard';
+
+export default function Page() {
+  return (
+    <main className="p-8 space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold mb-4">AI Customer Support</h1>
+        <Chat />
+      </div>
+      <Dashboard />
+    </main>
+  );
+}

--- a/frontend/components/Chat.jsx
+++ b/frontend/components/Chat.jsx
@@ -1,0 +1,65 @@
+"use client";
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+
+export default function Chat() {
+  // Pre-populate with dummy messages so the UI can be previewed without a backend.
+  const [messages, setMessages] = useState([
+    { role: 'user', text: 'What is your refund policy?' },
+    {
+      role: 'bot',
+      text: 'You can request a refund within 30 days of purchase. Please provide your order ID.',
+    },
+  ]);
+  const [input, setInput] = useState('');
+
+  const sendMessage = async () => {
+    if (!input) return;
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ question: input }),
+    });
+    const data = await res.json();
+    if (data.audio) {
+      const audio = new Audio(`data:audio/mp3;base64,${data.audio}`);
+      audio.play();
+    }
+    setMessages([
+      ...messages,
+      { role: 'user', text: input },
+      { role: 'bot', text: data.answer },
+    ]);
+    setInput('');
+  };
+
+  return (
+    <div>
+      <div className="h-64 overflow-y-auto border p-2 mb-4">
+        {messages.map((m, idx) => (
+          <motion.div
+            key={idx}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            className={`my-1 ${m.role === 'user' ? 'text-right' : 'text-left'}`}
+          >
+            <span className="inline-block px-2 py-1 rounded bg-gray-200">{m.text}</span>
+          </motion.div>
+        ))}
+      </div>
+      <div className="flex">
+        <input
+          className="flex-1 border px-2 py-1"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button
+          onClick={sendMessage}
+          className="ml-2 px-4 py-1 bg-blue-500 text-white rounded"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/Dashboard.jsx
+++ b/frontend/components/Dashboard.jsx
@@ -1,0 +1,55 @@
+"use client";
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+
+export default function Dashboard() {
+  // Dummy stats for UI preview
+  const stats = {
+    total: 42,
+    angry: 10,
+    happy: 24,
+    neutral: 8,
+    topQueries: [
+      'How do I reset my password?',
+      'Where is my order?',
+      'What is the refund policy?',
+    ],
+  };
+
+  const sentimentData = [
+    { name: 'Angry', value: stats.angry },
+    { name: 'Happy', value: stats.happy },
+    { name: 'Neutral', value: stats.neutral },
+  ];
+
+  const COLORS = ['#f87171', '#34d399', '#60a5fa'];
+
+  return (
+    <div className="p-4 border rounded mt-8 bg-white">
+      <h2 className="text-xl font-semibold mb-4">Analytics (Dummy)</h2>
+      <p className="mb-4">Total queries answered: {stats.total}</p>
+      <div className="h-48 mb-4">
+        <ResponsiveContainer>
+          <PieChart>
+            <Pie
+              data={sentimentData}
+              dataKey="value"
+              outerRadius={80}
+              label
+            >
+              {sentimentData.map((entry, idx) => (
+                <Cell key={`cell-${idx}`} fill={COLORS[idx % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+      <h3 className="font-medium mb-2">Top queries</h3>
+      <ul className="list-disc ml-6">
+        {stats.topQueries.map((q, idx) => (
+          <li key={idx}>{q}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    appDir: true,
+  },
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "next": "14.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "framer-motion": "10.16.4",
+    "recharts": "2.8.0"
+  },
+  "devDependencies": {
+    "tailwindcss": "3.4.1",
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.21"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./app/**/*.{js,jsx}", "./components/**/*.{js,jsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ai-customer-support-agent",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "echo \"No tests yet\""
+  }
+}


### PR DESCRIPTION
## Summary
- wire backend chat route to OpenAI for answer generation, sentiment classification, and speech synthesis
- play returned audio in the Next.js chat component and document OPENAI_API_KEY setup
- preload chat UI with sample conversation and add a dummy analytics dashboard using Recharts for preview

## Testing
- `npm test`
- `npm --prefix frontend test`
- `npm --prefix backend test`
- `npm --prefix frontend install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*

------
https://chatgpt.com/codex/tasks/task_e_68b1310b811c832ca88e3489bbcefd23