### PR TITLE
Connect frontend to backend analytics and chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,55 @@
 
 This repository contains a prototype for an AI-powered customer support agent. It includes a Next.js 14 frontend using Tailwind CSS and Framer Motion and an Express backend with Sequelize and PostgreSQL.
 
-## Structure
+## Architecture
 
-- `frontend/` – Next.js application with chat interface and a dummy analytics dashboard.
-- `backend/` – Express server with placeholder routes for chat and analytics.
+- **frontend/** – Next.js application with a chat interface and analytics dashboard.
+- **backend/** – Express server exposing REST endpoints and persisting queries via Sequelize.
 
-## Development
+### OpenAI integration
 
-Install dependencies for each package and run their respective development servers.
+The backend uses the official OpenAI Node.js SDK. `backend/services/openai.js` creates a client when the `OPENAI_API_KEY` environment variable is present. The chat route sends the user's question to the `gpt-4o-mini` model with a JSON schema that extracts an answer and sentiment label. The answer is also converted to speech with the `gpt-4o-mini-tts` model so the frontend can play audio responses.
 
-```
-cd frontend && npm install && npm run dev
-```
+On each request the backend stores the question and sentiment in Postgres. The analytics route aggregates these records to report total questions, sentiment breakdown, and most common queries.
+
+## Running the project
+
+Install dependencies and start both servers. The frontend uses `NEXT_PUBLIC_API_BASE` to locate the backend and defaults to `http://localhost:3001`.
+
 ```
 cd backend && npm install && npm start
 ```
 
-### Environment
+```
+cd frontend && npm install && npm run dev
+```
 
-The backend integrates with the OpenAI API for generating answers, sentiment, and voice output. Provide an API key before starting the server:
+Before starting the backend provide the OpenAI API key (and a `DATABASE_URL` if you want to persist data):
 
 ```
 export OPENAI_API_KEY=your_key_here
+export DATABASE_URL=postgres://user:pass@localhost:5432/aicsa   # optional
 ```
 
-The project currently provides only a minimal skeleton and does not implement full AI functionality. The frontend ships with dummy chat history and analytics so the UI can be previewed without the backend.
+## API overview
+
+- `POST /api/chat` – body `{ question: string }` → `{ answer, sentiment, audio }`
+- `GET /api/analytics` – returns counts of total, happy, angry, neutral, and the top queried questions
+
+## How it works
+
+1. The user types a question in the frontend chat component.
+2. The frontend POSTs the question to `/api/chat` on the backend.
+3. The backend asks OpenAI for an answer and sentiment and stores the record in Postgres.
+4. The backend returns the answer, sentiment, and optional speech audio to the frontend.
+5. The frontend displays the conversation and plays the audio. The dashboard fetches `/api/analytics` to show usage statistics.
+
+## Testing
+
+Run the tests from the repository root:
+
+```
+npm test
+cd backend && npm test
+cd frontend && npm test
+```

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const fileUpload = require('express-fileupload');
+const cors = require('cors');
 const { sequelize } = require('./models');
 const chatRoutes = require('./routes/chat');
 const analyticsRoutes = require('./routes/analytics');
 
 const app = express();
+app.use(cors());
 app.use(bodyParser.json());
 app.use(fileUpload());
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "sequelize": "6.35.1",
     "pg": "8.10.0",
     "express-fileupload": "1.4.0",
-    "openai": "^4.24.1"
+    "openai": "^4.24.1",
+    "cors": "2.8.5"
   }
 }

--- a/frontend/components/Chat.jsx
+++ b/frontend/components/Chat.jsx
@@ -3,33 +3,31 @@ import { useState } from 'react';
 import { motion } from 'framer-motion';
 
 export default function Chat() {
-  // Pre-populate with dummy messages so the UI can be previewed without a backend.
-  const [messages, setMessages] = useState([
-    { role: 'user', text: 'What is your refund policy?' },
-    {
-      role: 'bot',
-      text: 'You can request a refund within 30 days of purchase. Please provide your order ID.',
-    },
-  ]);
+  const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
+  const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:3001';
 
   const sendMessage = async () => {
     if (!input) return;
-    const res = await fetch('/api/chat', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ question: input }),
-    });
-    const data = await res.json();
-    if (data.audio) {
-      const audio = new Audio(`data:audio/mp3;base64,${data.audio}`);
-      audio.play();
+    try {
+      const res = await fetch(`${API_BASE}/api/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: input }),
+      });
+      const data = await res.json();
+      if (data.audio) {
+        const audio = new Audio(`data:audio/mp3;base64,${data.audio}`);
+        audio.play();
+      }
+      setMessages([
+        ...messages,
+        { role: 'user', text: input },
+        { role: 'bot', text: data.answer },
+      ]);
+    } catch (err) {
+      console.error(err);
     }
-    setMessages([
-      ...messages,
-      { role: 'user', text: input },
-      { role: 'bot', text: data.answer },
-    ]);
     setInput('');
   };
 

--- a/frontend/components/Dashboard.jsx
+++ b/frontend/components/Dashboard.jsx
@@ -1,19 +1,39 @@
 "use client";
+import { useEffect, useState } from 'react';
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
 
 export default function Dashboard() {
-  // Dummy stats for UI preview
-  const stats = {
-    total: 42,
-    angry: 10,
-    happy: 24,
-    neutral: 8,
-    topQueries: [
-      'How do I reset my password?',
-      'Where is my order?',
-      'What is the refund policy?',
-    ],
-  };
+  const [stats, setStats] = useState(null);
+  const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:3001';
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`${API_BASE}/api/analytics`);
+        const data = await res.json();
+        const neutral = data.total - (data.angry + data.happy);
+        setStats({
+          total: data.total,
+          angry: data.angry,
+          happy: data.happy,
+          neutral,
+          topQueries: data.top.map((t) => t.question),
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, []);
+
+  if (!stats) {
+    return (
+      <div className="p-4 border rounded mt-8 bg-white">
+        <h2 className="text-xl font-semibold mb-4">Analytics</h2>
+        <p>Loading...</p>
+      </div>
+    );
+  }
 
   const sentimentData = [
     { name: 'Angry', value: stats.angry },
@@ -25,7 +45,7 @@ export default function Dashboard() {
 
   return (
     <div className="p-4 border rounded mt-8 bg-white">
-      <h2 className="text-xl font-semibold mb-4">Analytics (Dummy)</h2>
+      <h2 className="text-xl font-semibold mb-4">Analytics</h2>
       <p className="mb-4">Total queries answered: {stats.total}</p>
       <div className="h-48 mb-4">
         <ResponsiveContainer>


### PR DESCRIPTION
## Summary
- enable CORS in Express backend so Next.js frontend can access APIs
- wire chat component to backend and play audio responses
- hook analytics dashboard to live query stats

## Testing
- `npm test`
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b134ea06ac832ca490a80dd29b7c98