### PR TITLE
feat: add PDF upload and question answering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Customer Support Agent
 
-This repository contains a prototype for an AI-powered customer support agent. It includes a Next.js 14 frontend using Tailwind CSS and Framer Motion and an Express backend with Sequelize and PostgreSQL.
+This repository contains a prototype for an AI-powered customer support agent. It includes a Next.js 14 frontend using Tailwind CSS and Framer Motion and an Express backend with Sequelize and PostgreSQL. Users can optionally upload a PDF which is parsed and used as context when answering questions.
 
 ## Architecture
 
@@ -34,16 +34,18 @@ export DATABASE_URL=postgres://user:pass@localhost:5432/aicsa   # optional
 
 ## API overview
 
-- `POST /api/chat` – body `{ question: string }` → `{ answer, sentiment, audio }`
+- `POST /api/upload` – multipart form-data with field `file` (PDF) → `{ text }`
+- `POST /api/chat` – body `{ question: string, pdfText?: string }` → `{ answer, sentiment, audio }`
 - `GET /api/analytics` – returns counts of total, happy, angry, neutral, and the top queried questions
 
 ## How it works
 
 1. The user types a question in the frontend chat component.
-2. The frontend POSTs the question to `/api/chat` on the backend.
-3. The backend asks OpenAI for an answer and sentiment and stores the record in Postgres.
-4. The backend returns the answer, sentiment, and optional speech audio to the frontend.
-5. The frontend displays the conversation and plays the audio. The dashboard fetches `/api/analytics` to show usage statistics.
+2. The user may upload a PDF which the frontend sends to `/api/upload`; the backend extracts its text.
+3. The frontend POSTs the question (and extracted text if available) to `/api/chat` on the backend.
+4. The backend asks OpenAI for an answer and sentiment using the document text as context and stores the record in Postgres.
+5. The backend returns the answer, sentiment, and optional speech audio to the frontend.
+6. The frontend displays the conversation and plays the audio. The dashboard fetches `/api/analytics` to show usage statistics.
 
 ## Testing
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const fileUpload = require('express-fileupload');
 const cors = require('cors');
+const pdfParse = require('pdf-parse');
 const { sequelize } = require('./models');
 const chatRoutes = require('./routes/chat');
 const analyticsRoutes = require('./routes/analytics');
@@ -11,8 +12,18 @@ app.use(cors());
 app.use(bodyParser.json());
 app.use(fileUpload());
 
-app.post('/api/upload', (req, res) => {
-  res.json({ status: 'uploaded' });
+app.post('/api/upload', async (req, res) => {
+  if (!req.files || !req.files.file) {
+    return res.status(400).json({ error: 'No file uploaded' });
+  }
+  try {
+    const dataBuffer = req.files.file.data;
+    const pdf = await pdfParse(dataBuffer);
+    res.json({ text: pdf.text });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to process PDF' });
+  }
 });
 
 app.use('/api/chat', chatRoutes);

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "pg": "8.10.0",
     "express-fileupload": "1.4.0",
     "openai": "^4.24.1",
-    "cors": "2.8.5"
+    "cors": "2.8.5",
+    "pdf-parse": "^1.1.1"
   }
 }

--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -4,23 +4,31 @@ const Query = require('../models/query');
 const openai = require('../services/openai');
 
 router.post('/', async (req, res) => {
-  const { question } = req.body;
+  const { question, pdfText } = req.body;
   let answer = 'Placeholder answer';
   let sentiment = 'neutral';
   let audio = null;
 
   try {
     if (openai) {
+      const messages = [
+        {
+          role: 'system',
+          content:
+            'You are a helpful support agent. Reply in JSON with keys answer and sentiment (angry, neutral, happy).',
+        },
+      ];
+      if (pdfText) {
+        messages.push({
+          role: 'system',
+          content: `Document content:\n${pdfText.slice(0, 2000)}`,
+        });
+      }
+      messages.push({ role: 'user', content: question });
+
       const completion = await openai.chat.completions.create({
         model: 'gpt-4o-mini',
-        messages: [
-          {
-            role: 'system',
-            content:
-              'You are a helpful support agent. Reply in JSON with keys answer and sentiment (angry, neutral, happy).',
-          },
-          { role: 'user', content: question },
-        ],
+        messages,
         response_format: {
           type: 'json_schema',
           json_schema: {

--- a/frontend/components/Chat.jsx
+++ b/frontend/components/Chat.jsx
@@ -6,7 +6,25 @@ import { FiSend, FiUser, FiCpu } from 'react-icons/fi';
 export default function Chat() {
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
+  const [pdfText, setPdfText] = useState('');
   const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:3001';
+
+  const handleUpload = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    try {
+      const res = await fetch(`${API_BASE}/api/upload`, {
+        method: 'POST',
+        body: formData,
+      });
+      const data = await res.json();
+      setPdfText(data.text || '');
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   const sendMessage = async () => {
     if (!input) return;
@@ -14,7 +32,7 @@ export default function Chat() {
       const res = await fetch(`${API_BASE}/api/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ question: input }),
+        body: JSON.stringify({ question: input, pdfText }),
       });
       const data = await res.json();
       if (data.audio) {
@@ -34,6 +52,12 @@ export default function Chat() {
 
   return (
     <div className="flex flex-col h-full">
+      <input
+        type="file"
+        accept="application/pdf"
+        onChange={handleUpload}
+        className="mb-2"
+      />
       <div className="flex-1 overflow-y-auto p-4 mb-4 bg-gray-800/50 rounded-lg space-y-2">
         {messages.map((m, idx) => (
           <motion.div


### PR DESCRIPTION
## Summary
- allow uploading PDFs and extract text for context
- use uploaded document text when answering chat questions
- document new PDF upload workflow and API endpoint

## Testing
- `npm test`
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b139ddb3b0832ca1c5b8f270ec8b01