### PR TITLE
feat: add nodemon and migrations

### DIFF
--- a/backend/.sequelizerc
+++ b/backend/.sequelizerc
@@ -1,0 +1,7 @@
+const path = require('path');
+
+module.exports = {
+  config: path.resolve('config', 'config.js'),
+  'models-path': path.resolve('models'),
+  'migrations-path': path.resolve('migrations'),
+};

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -1,0 +1,12 @@
+require('dotenv').config();
+
+module.exports = {
+  development: {
+    url: process.env.DATABASE_URL || 'postgres://user:pass@localhost:5432/aicsa',
+    dialect: 'postgres',
+  },
+  production: {
+    url: process.env.DATABASE_URL,
+    dialect: 'postgres',
+  },
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const bodyParser = require('body-parser');
 const fileUpload = require('express-fileupload');
@@ -30,6 +31,11 @@ app.use('/api/chat', chatRoutes);
 app.use('/api/analytics', analyticsRoutes);
 
 const PORT = process.env.PORT || 3001;
-sequelize.sync().then(() => {
-  app.listen(PORT, () => console.log(`Server running on ${PORT}`));
-});
+sequelize
+  .authenticate()
+  .then(() => {
+    app.listen(PORT, () => console.log(`Server running on ${PORT}`));
+  })
+  .catch((err) => {
+    console.error('Unable to connect to database:', err);
+  });

--- a/backend/migrations/20240524000000-create-query.js
+++ b/backend/migrations/20240524000000-create-query.js
@@ -1,0 +1,32 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Queries', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      question: {
+        type: Sequelize.TEXT,
+      },
+      sentiment: {
+        type: Sequelize.STRING,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('Queries');
+  },
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,7 +1,8 @@
 const { Sequelize } = require('sequelize');
+const config = require('../config/config')[process.env.NODE_ENV || 'development'];
 
-const sequelize = new Sequelize(process.env.DATABASE_URL || 'postgres://user:pass@localhost:5432/aicsa', {
-  dialect: 'postgres',
+const sequelize = new Sequelize(config.url, {
+  dialect: config.dialect,
   logging: false,
 });
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
+    "dev": "nodemon index.js",
+    "migrate": "sequelize db:migrate",
     "test": "echo \"No tests yet\""
   },
   "dependencies": {
@@ -14,6 +16,11 @@
     "express-fileupload": "1.4.0",
     "openai": "^4.24.1",
     "cors": "2.8.5",
-    "pdf-parse": "^1.1.1"
+    "pdf-parse": "^1.1.1",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1",
+    "sequelize-cli": "^6.6.1"
   }
 }


### PR DESCRIPTION
## Summary
- add nodemon dev script and sequelize-cli for database migrations
- configure Sequelize with environment-based config and migration support
- create initial migration for `Query` table

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*
- `npm test`
- `npm run migrate` *(fails: sequelize: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b13dd1ec48832c85da9ec226757e22